### PR TITLE
指定扩充词表中加载模型的精度

### DIFF
--- a/engines/models.py
+++ b/engines/models.py
@@ -283,5 +283,6 @@ class BaseModels:
             self.data_manager.data_args.corpus_path_for_expansion,
             self.model_args.model_type,
             self.model_args.save_path_after_vocab_expansion,
+            self.model_args.torch_dtype,
             self.training_args
         )

--- a/engines/utils/expand_vocab.py
+++ b/engines/utils/expand_vocab.py
@@ -93,12 +93,19 @@ def expand_vocab(logger,
                  corpus_path,
                  model_arch,
                  save_path,
+                 torch_dtype,
                  args
                  ):
     logger.info(f'Load base tokenizer from {model_path}.')
     tokenizer = AutoTokenizer.from_pretrained(model_path)
+
     logger.info(f'Load base model from {model_path}'.capitalize)
-    model = AutoModel.from_pretrained(model_path, trust_remote_code=True)
+    model = AutoModel.from_pretrained(
+        model_path,
+        trust_remote_code=True,
+        torch_dtype=torch_dtype
+    )
+    
     save_path = os.path.join(model_path, 'new_model') if save_path == 'auto' else save_path
     os.makedirs(save_path, exist_ok=True)
     logger.info(f'After expanding the vocabulary, the new model will be saved to {save_path}.')


### PR DESCRIPTION
扩充词表中，之前 load model 的时候没有指定加载精度，会以默认的 float32 精度加载，现在加上这个参数设置，此参数继承于全局的 `torch_dtype`