### PR TITLE
设置QLoRA的target_modules为全部线性层

### DIFF
--- a/config.py
+++ b/config.py
@@ -515,7 +515,7 @@ class TrainingArguments(Seq2SeqTrainingArguments):
         }
     )
     noise_alpha: Optional[float] = field(
-        default=5,
+        default=0,
         metadata={
             # 使用NEFTune对模型进行Noise Tune，https://arxiv.org/abs/2310.05914
             'help': 'Whether to use Noisy Embedding Fine Tuning, if you want using it, set noise_alpha > 0.'


### PR DESCRIPTION
1. 将 NEFTune 中才用到的 `noise_alpha` 默认设置为 0，否则启动其他工作模式的时候会报错

2. 设置 QLoRA 的 target_modules 为全部线性层，这是根据 [QLoRA](https://github.com/artidoro/qlora/blob/7f4e95a68dc076bea9b3a413d2b512eca6d004e5/qlora.py#L385) 源码实现的，增加了训练参数，弥补精度带来的性能损失